### PR TITLE
use new plugin to start Deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,9 +46,9 @@ jobs:
               run: hugo --minify --gc
 
             - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@4.1.4
-              with:
-                  branch: gh-pages
-                  folder: public
-                  clean: true
-                  single-commit: true
+              uses: s0/git-publish-subdir-action@develop
+              env:
+                REPO: self
+                BRANCH: gh-pages
+                FOLDER: public
+                GITHUB_TOKEN: ${{ secrets.FLOW_TOKEN }}


### PR DESCRIPTION
I saw this github action was failed to run because of deploy job is failed, I fixed it now. Follow steps below:

> 1. get token from personal settings
> 2. repo `secerts` set `FLOW_TOKEN` key and token value

Then workflow will run success.