### PR TITLE
 ci: use Hugo 0.111.3 for Deploy to Github Pages action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
             - name: Setup Hugo
               uses: peaceiris/actions-hugo@v2
               with:
-                  hugo-version: "latest"
+                  hugo-version: 0.111.3
                   extended: true
 
             - name: Build


### PR DESCRIPTION
Using the latest version of Hugo is breaking this github actions workflow. Swapping this over to 0.111.3 (which is in line with the update theme workflow) ensures this functions correctly.