### PR TITLE
chore: update GitHub Action dependencies to the latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,30 +16,20 @@ jobs:
             contents: write
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Cache Hugo resources
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               env:
                   cache-name: cache-hugo-resources
               with:
                   path: resources
                   key: ${{ env.cache-name }}
 
-            - uses: actions/setup-go@v2
+            - uses: actions/setup-go@v4
               with:
                   go-version: "^1.17.0"
             - run: go version
-
-            - name: Cache Go Modules
-              uses: actions/cache@v2
-              with:
-                  path: |
-                      ~/.cache/go-build
-                      ~/go/pkg/mod
-                  key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-                  restore-keys: |
-                      ${{ runner.os }}-go-
 
             - name: Setup Hugo
               uses: peaceiris/actions-hugo@v2
@@ -51,7 +41,7 @@ jobs:
               run: hugo --minify --gc
 
             - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@4.1.4
+              uses: JamesIves/github-pages-deploy-action@v4
               with:
                   branch: gh-pages
                   folder: public

--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
Remove the step which creates cache for Go modules since it's integrated now in actions/setup-go@v4