### PR TITLE
fix: update GitHub Actions to fetch full Git history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
             - name: Cache Hugo resources
               uses: actions/cache@v3


### PR DESCRIPTION
Changed the `fetch-depth` option in the checkout step to `0`. This enables the workflow to access the full commit history, which is necessary for Hugo's `enableGitInfo` feature to function correctly.