### PR TITLE
ci: bump GitHub workflow actions to their latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,17 +16,17 @@ jobs:
             contents: write
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Cache Hugo resources
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               env:
                   cache-name: cache-hugo-resources
               with:
                   path: resources
                   key: ${{ env.cache-name }}
 
-            - uses: actions/setup-go@v4
+            - uses: actions/setup-go@v5
               with:
                   go-version: "^1.17.0"
             - run: go version

--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -18,12 +18,12 @@ jobs:
       contents: write
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 0.115.2
+          hugo-version: 0.123.8
           extended: true
 
       - name: Update theme
@@ -33,6 +33,6 @@ jobs:
         run: hugo mod tidy
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "CI: Update theme"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public
 resources
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ It comes with a basic theme structure and configuration. GitHub action has been 
 1. Click *Use this template*, and create your repository on GitHub.
 ![Step 1](https://user-images.githubusercontent.com/5889006/156916624-20b2a784-f3a9-4718-aa5f-ce2a436b241f.png)
 
-2. Once the repository is created, create a GitHub codespace asociated with it.
+2. Once the repository is created, create a GitHub codespace associated with it.
 ![Create codespace](https://user-images.githubusercontent.com/5889006/156916672-43b7b6e9-4ffb-4704-b4ba-d5ca40ffcae7.png)
 
 3. And voila! You're ready to go. The codespace has been configured with the latest version of Hugo extended, just run `hugo server` in the terminal and see your new site in action.
 
 4. Check `config` folder for the configuration files. You can edit them to suit your needs. Make sure to update the `baseurl` property in `config/_default/config.toml` to your site's URL.
 
-5. Once you're done editing the site, just commit it and push it. GitHub action will deploy the site automatically to GitHub page asociated with the repository.
+5. Once you're done editing the site, just commit it and push it. GitHub action will deploy the site automatically to GitHub page associated with the repository.
 ![GitHub action](https://user-images.githubusercontent.com/5889006/156916881-90b8bb9b-1925-4e60-9d7a-8026cda729bf.png)
 
 ---


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions.
It also fixes two typos on the way.