### PR TITLE
doc: update Vercel Golang installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ amazon-linux-extras install golang1.11 && hugo --gc --minify
 
 ![](https://user-images.githubusercontent.com/5889006/156917172-01e4d418-3469-4ffb-97e4-a905d28b8424.png)
 
+If you are using Node.js 20, you need to overwrite the install command to install manually Go:
+
+```
+dnf install -y golang
+```
+
+![image](https://github.com/zhi-yi-huang/hugo-theme-stack-starter/assets/83860323/777c1109-dfc8-4893-9db7-1305ec027cf5)
+
+
 Make sure also to specify Hugo version in the environment variable `HUGO_VERSION` (Use the latest version of Hugo extended):
 
 ![Environment variable](https://user-images.githubusercontent.com/5889006/156917212-afb7c70d-ab85-480f-8288-b15781a462c0.png)


### PR DESCRIPTION
According to the [vercel documentation](https://vercel.com/docs/deployments/build-image/build-image), add a deployment setting under Node.js 20.x.