### PR TITLE
fix: some math formulas can not be displayed

### DIFF
--- a/config/_default/markup.toml
+++ b/config/_default/markup.toml
@@ -2,6 +2,15 @@
 [goldmark.renderer]
 unsafe = true
 
+[goldmark.extensions.passthrough]
+enable = true
+
+# LaTeX math support
+# https://gohugo.io/content-management/mathematics/
+[goldmark.extensions.passthrough.delimiters]
+block = [['\[', '\]'], ['$$', '$$']]
+inline = [['\(', '\)']]
+
 [tableOfContents]
 endLevel = 4
 ordered = true


### PR DESCRIPTION
Related https://github.com/CaiJimmy/hugo-theme-stack/issues/1019