### PR TITLE
Improve GitHub Pages Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,24 @@ on:
         branches: [master]
     pull_request:
         branches: [master]
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
     build:
         runs-on: ubuntu-latest
-
-        permissions:
-            # Give the default GITHUB_TOKEN write permission to commit and push the
-            # added or changed files to the repository.
-            contents: write
 
         steps:
             - uses: actions/checkout@v4
@@ -38,14 +47,26 @@ jobs:
               with:
                   hugo-version: "latest"
                   extended: true
-
+                  
+            - name: Setup Pages
+              id: pages
+              uses: actions/configure-pages@v5
+              
             - name: Build
-              run: hugo --minify --gc
-
-            - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@v4
+              run: hugo --minify --gc --baseURL "${{ steps.pages.outputs.base_url }}/"
+              
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
               with:
-                  branch: gh-pages
-                  folder: public
-                  clean: true
-                  single-commit: true
+                path: ./public
+
+    deploy:
+      environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
+      runs-on: ubuntu-latest
+      needs: build
+      steps:
+        - name: Deploy to GitHub Pages
+          id: deployment
+          uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to improve the deployment process for GitHub Pages. The changes include enabling manual workflow execution, refining permissions, enhancing concurrency management, and switching to the official `actions/deploy-pages` action.

`steps.deployment.outputs.base_url` Explanation:
This output provides the final deployed URL of the GitHub Pages site. It is automatically generated by `actions/deploy-pages@v4`, ensuring the correct URL is used in the workflow without hardcoding it.